### PR TITLE
handle link blocks properly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "utonium"
-version = "0.6.0"
+version = "0.6.1"
 description = "The Slack Bolt plugin handler it always wanted."
 authors = ["Grafeas Group Ltd. <devs@grafeas.org>"]
 readme = "README.md"

--- a/utonium/__init__.py
+++ b/utonium/__init__.py
@@ -430,6 +430,11 @@ class PluginManager:
         payload_obj = Payload(
             client=client, slack_payload=payload, say=say, context=context, meta=self
         )
+
+        if not payload_obj.get_block_kit_action():
+            # something's wonky or it's a link button. Just return so that all is good.
+            return
+
         for plugin in self.block_kit_action_plugins:
             if re.search(
                 plugin.block_kit_action_regex, payload_obj.get_block_kit_action()


### PR DESCRIPTION
## Description:

After chatting with Slack support, now we know why the link blocks were failing; it triggers an action payload that _has no action_, which utonium was tripping on.